### PR TITLE
upgrade to `fountain-js` v 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Sarang Joshi <sarangj@msn.com>",
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "fountain.ts": "^0.1.0"
+    "fountain-js": "^1.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0",

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -1,4 +1,4 @@
-const { Fountain } = require(`fountain.ts`);
+const { Fountain } = require(`fountain-js`);
 
 async function onCreateNode({
   node,


### PR DESCRIPTION
Just letting you know that I've renamed `Fountain.ts` to `fountain-js`. 

You can now find the NPM package at <https://www.npmjs.com/package/fountain-js>.

Install:

```
npm install fountain-js
```

Note the import statement is now different too:

``` javascript
const { Fountain } = require('fountain-js');
```